### PR TITLE
Task/bam 143 change to manual release

### DIFF
--- a/.github/workflows/php-build.yml
+++ b/.github/workflows/php-build.yml
@@ -1,8 +1,6 @@
 name: PHP Build and Release
 
 on:
-  repository_dispatch:
-    types: [tag-push]
   workflow_dispatch:
 
 jobs:
@@ -148,12 +146,19 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
       prerelease: ${{ steps.tag.outputs.prerelease }}
     steps:
-      - name: Use the tag from the event
+      - name: Fetch latest tag from kody-protocols-clientsdk
         id: tag
         run: |
-          echo "TAG from event: ${{ github.event.client_payload.tag }}"
-          echo "tag=${{ github.event.client_payload.tag }}" >> $GITHUB_OUTPUT
-          if [[ "${{ github.event.client_payload.tag }}" == *-* ]]; then echo "prerelease=true" >> $GITHUB_OUTPUT; else echo "prerelease=false" >> $GITHUB_OUTPUT; fi
+          git clone --branch main https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
+          cd proto-repo
+          head_tag=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
+          if [[ -z "${head_tag}" ]]; then
+            echo "No tag found on the head commit of kp-protocols-clientsdk repo. Failing the action."
+            exit 1
+          else
+            echo "tag=${head_tag}" >> $GITHUB_OUTPUT
+            if [[ "${head_tag}" == *-* ]]; then echo "prerelease=true" >> $GITHUB_OUTPUT; else echo "prerelease=false" >> $GITHUB_OUTPUT; fi
+          fi
 
   release:
     needs:

--- a/.github/workflows/php-build.yml
+++ b/.github/workflows/php-build.yml
@@ -146,7 +146,7 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
       prerelease: ${{ steps.tag.outputs.prerelease }}
     steps:
-      - name: Fetch latest tag from kody-protocols-clientsdk
+      - name: Fetch head tag from kp-protocols-clientsdk
         id: tag
         run: |
           git clone --branch main https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo


### PR DESCRIPTION
**What has changed**

1. Dispatch from protocols repo is to be removed, so we remove the trigger rely on it.
3. Tags now to be acquired from the head commit of public protobuf spec repo (kp-protocols-clientsdk).
4. Build will fail if the head commit contains no tag.

**Reason**

1. This approach avoids privilege issues as public repositories (e.g., protobuf specs) can be accessed by private repositories without requiring special tokens or permissions.
2. It provides manual control over each SDK’s release, ensuring readiness (e.g., documentation and examples) before public release.
