### PR TITLE
Task/bam 161 release from an input tag in anywhere

### DIFF
--- a/.github/workflows/php-build.yml
+++ b/.github/workflows/php-build.yml
@@ -2,6 +2,11 @@ name: PHP Build and Release
 
 on:
   workflow_dispatch:
+    inputs:
+      kp_tag:
+        description: 'Optional tag for kp-protocols-clientsdk'
+        required: false
+        default: ''
 
 jobs:
   prepare-grpc-plugin:
@@ -29,14 +34,20 @@ jobs:
   build-php7-package:
     needs:
       - prepare-grpc-plugin
+      - tagging
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Checkout proto repository
+      - &checkout-proto-repo
+        name: Checkout proto repository
         run: |
           git clone https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
+          cd proto-repo || { echo "Failed to change directory to proto-repo"; exit 1; }
+          git checkout tags/${{ needs.tagging.outputs.tag }} -b temp-branch || { echo "Failed to checkout tag ${{ needs.tagging.outputs.tag }}"; exit 1; }
+          
+          cd ..
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -84,14 +95,13 @@ jobs:
   build-php8-package:
     needs:
       - prepare-grpc-plugin
+      - tagging
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Checkout proto repository
-        run: |
-          git clone https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
+      - *checkout-proto-repo
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -146,18 +156,23 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
       prerelease: ${{ steps.tag.outputs.prerelease }}
     steps:
-      - name: Fetch head tag from kp-protocols-clientsdk
+      - name: Determine version tag from kp-protocols-clientsdk
         id: tag
         run: |
-          git clone --branch main https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
-          cd proto-repo
-          head_tag=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
-          if [[ -z "${head_tag}" ]]; then
+          if [ -n "${{ github.event.inputs.kp_tag }}" ]; then
+             version_tag=${{ github.event.inputs.kp_tag }}
+          else
+            git clone --branch main https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
+            cd proto-repo
+            version_tag=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
+          fi
+          if [[ -z "${version_tag}" ]]; then
             echo "No tag found on the head commit of kp-protocols-clientsdk repo. Failing the action."
             exit 1
           else
-            echo "tag=${head_tag}" >> $GITHUB_OUTPUT
-            if [[ "${head_tag}" == *-* ]]; then echo "prerelease=true" >> $GITHUB_OUTPUT; else echo "prerelease=false" >> $GITHUB_OUTPUT; fi
+            echo "tag=${version_tag}" >> $GITHUB_OUTPUT
+            echo "version=${version_tag#v}" >> $GITHUB_OUTPUT
+            if [[ "${version_tag}" == *-* ]]; then echo "prerelease=true" >> $GITHUB_OUTPUT; else echo "prerelease=false" >> $GITHUB_OUTPUT; fi
           fi
 
   release:

--- a/.github/workflows/php-build.yml
+++ b/.github/workflows/php-build.yml
@@ -40,8 +40,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - &checkout-proto-repo
-        name: Checkout proto repository
+      - name: Checkout proto repository
         run: |
           git clone https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
           cd proto-repo || { echo "Failed to change directory to proto-repo"; exit 1; }
@@ -100,9 +99,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - *checkout-proto-repo
-
+      - name: Checkout proto repository
+        run: |
+          git clone https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
+          cd proto-repo || { echo "Failed to change directory to proto-repo"; exit 1; }
+          git checkout tags/${{ needs.tagging.outputs.tag }} -b temp-branch || { echo "Failed to checkout tag ${{ needs.tagging.outputs.tag }}"; exit 1; }
+          
+          cd ..
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
**Associated JIRA tasks**

BAM-161

**What does the change do?**

For a new project, we may want to release an SDK with an alpha(prerelease) version of our specification to our customers to gather early feedback. The alpha version of the specification might still be under review and reside in a task or feature branch.
Additionally, for developers, it can be beneficial to release a prerelease version of the SDK. This allows them to begin working on a specification that hasn’t been fully finalized, especially in situations requiring urgent progress.

**What has been changed**

To be able to release the such sdk from an alpha version spec, the action from the sdk repo need to checkout the protobuf spec using a manual input tag.
Also included new spec to be published for user to try


**Test**
Run from task branch being successful.
https://github.com/KodyPay/kody-clientsdk-php/actions/runs/12832002947