### PR TITLE
Refactor Payment Confirmation to Use PaymentDetails as Source of Truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To install the Kody PHP gRPC Client, simply add it to your project's `composer.j
                 "version": "v1.5.4",
                 "dist": {
                     "type": "zip",
-                    "url": "https://github.com/kody-joao/kody-clientsdk-php/releases/download/v1.5.4/kody-php8-grpc-package.zip"
+                    "url": "https://github.com/KodyPay/kody-clientsdk-php/releases/download/v1.5.4/kody-php8-grpc-package.zip"
                 }
             }
         }


### PR DESCRIPTION
This PR simplifies the payment confirmation process by using the PaymentDetails response (from gRPC) as the single source of truth.

Validation in Main Logic:
The main logic optionally compares an expected status (if provided) against the actual status. If they don’t match, an exception is thrown.

Different Cases Handled:

- Success: Displays "Payment was successful!"
- Failed: Displays "Payment status: Failed"
- Cancelled: Displays "Payment status: Cancelled"
- Expired: Displays "Payment status: Expired"

When the actual status matches with expected status from URL param:

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/d8011557-9165-4d8e-91da-4679e091b4fd" />

When the actual status doesn't match with expected status from URL param:
Displays a generic error message

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/fe8d4af0-ca29-4a61-829d-e430d5062ac5" />
