### PR TITLE
fix: use bookworm base images to fix arm64 build

### DIFF
--- a/samples/php8/ecom-server/Dockerfile
+++ b/samples/php8/ecom-server/Dockerfile
@@ -1,6 +1,6 @@
-FROM composer:latest as composer
+FROM composer:latest AS composer
 
-FROM php:8.3-bullseye as grpc-base
+FROM php:8.3-bookworm AS grpc-base
 
 RUN apt-get -qq update && apt-get -qq install -y \
   libprotobuf-dev protobuf-compiler
@@ -8,7 +8,7 @@ RUN apt-get -qq update && apt-get -qq install -y \
 RUN pecl install grpc
 
 ######################
-FROM php:8.3-fpm-bullseye
+FROM php:8.3-fpm-bookworm
 
 RUN apt-get -qq update && apt-get -qq install -y \
   git zip unzip


### PR DESCRIPTION
## Summary

- Upgrade Dockerfile base images from Debian **bullseye** to **bookworm**
- Fix `AS` keyword casing to suppress buildx warnings

## Problem

The multi-arch Docker build (`linux/amd64,linux/arm64`) added in #68 fails on the arm64 leg with:

```
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
dpkg: error processing package libc-bin (--configure)
```

This is a known QEMU user-mode emulation incompatibility with bullseye's `libc-bin` post-install scripts when running arm64 on amd64 runners.

## Fix

Switch from `php:8.3-bullseye` / `php:8.3-fpm-bullseye` to `php:8.3-bookworm` / `php:8.3-fpm-bookworm`. Bookworm's libc works correctly under QEMU emulation.

## Test plan

- [ ] Merge → manual `workflow_dispatch` on `php-docker-publish.yml` → verify both amd64 and arm64 manifests in `ghcr.io/kodypay/kody-clientsdk-php:latest`
- [ ] Verify `ecom-php-demo` pod starts on arm64 (Graviton) nodes in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)